### PR TITLE
Allow currencies with exactly 8 decimal places (Bitcoin, Litecoin).

### DIFF
--- a/src/main/java/org/joda/money/DefaultCurrencyUnitDataProvider.java
+++ b/src/main/java/org/joda/money/DefaultCurrencyUnitDataProvider.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 class DefaultCurrencyUnitDataProvider extends CurrencyUnitDataProvider {
 
     /** Regex format for the csv line. */
-    private static final Pattern REGEX_LINE = Pattern.compile("([A-Z]{3}),(-1|[0-9]{1,3}),(-1|0|1|2|3),([A-Z]*)#?.*");
+    private static final Pattern REGEX_LINE = Pattern.compile("([A-Z]{3}),(-1|[0-9]{1,3}),(-1|0|1|2|3|8),([A-Z]*)#?.*");
 
     /**
      * Registers all the currencies known by this provider.


### PR DESCRIPTION
Hello,

I am using the MoneyDataExtension.csv file to add support for Bitcoin and Litecoin to my application. These currencies are usable down to 8 decimal places.

DefaultCurrencyUnitDataProvider currently only accepts "-1|1|2|3" when defining a currency's scale in the CSV file.

This patch alters the regular expression to allow it to accept 8 as well.

Alternatively, you could do something like -1|[1-8].
