### PR TITLE
Allow up to 9 decimal places to be defined in CSV file.

### DIFF
--- a/src/main/java/org/joda/money/DefaultCurrencyUnitDataProvider.java
+++ b/src/main/java/org/joda/money/DefaultCurrencyUnitDataProvider.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 class DefaultCurrencyUnitDataProvider extends CurrencyUnitDataProvider {
 
     /** Regex format for the csv line. */
-    private static final Pattern REGEX_LINE = Pattern.compile("([A-Z]{3}),(-1|[0-9]{1,3}),(-1|0|1|2|3),([A-Z]*)#?.*");
+    private static final Pattern REGEX_LINE = Pattern.compile("([A-Z]{3}),(-1|[0-9]{1,3}),(-1|[0-9]),([A-Z]*)#?.*");
 
     /**
      * Registers all the currencies known by this provider.


### PR DESCRIPTION
DefaultCurrencyUnitDataProvider currently only allows up to 3 decimal places to be defined in the CSV file. 

This patch increases that to 9 places, which is the maximum allowed by CurrencyUnit.registerCurrency(...).
