### PR TITLE
Enable the Travis continuous integration system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# This file enables the Travis continuous integration system, which
+# automatically builds and tests joda-money for each GitHub commit or 
+# pull request on three separate JDKs.
+#
+# For more information, see https://travis-ci.org
+
+language: java
+
+jdk: 
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+


### PR DESCRIPTION
This pull request enables the Travis CI system.

http://travis-ci.org will automatically build joda-money on every commit or pull request. It shows a nice green bar on pull requests within GitHub to let you know they are safe to apply, and emails developers when the build is broken.

This is a free service integrated with GitHub.
