### PR TITLE
Add missing checkNotNull for amount parameter on Money.of method

### DIFF
--- a/src/main/java/org/joda/money/Money.java
+++ b/src/main/java/org/joda/money/Money.java
@@ -70,6 +70,7 @@ public final class Money implements BigMoneyProvider, Comparable<BigMoneyProvide
      */
     public static Money of(CurrencyUnit currency, BigDecimal amount) {
         MoneyUtils.checkNotNull(currency, "Currency must not be null");
+        MoneyUtils.checkNotNull(amount, "Amount must not be null");
         if (amount.scale() > currency.getDecimalPlaces()) {
             throw new ArithmeticException("Scale of amount " + amount + " is greater than the scale of the currency " + currency);
         }


### PR DESCRIPTION
Added a missing checkNotNull guard to avoid throwing an NPE on the following line in cases where amount is passed in as null.
