### PR TITLE
Adjusted the BigMoney#equals according to the BigDecimal implementation details

### DIFF
--- a/src/main/java/org/joda/money/BigMoney.java
+++ b/src/main/java/org/joda/money/BigMoney.java
@@ -774,7 +774,7 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      */
     public BigMoney withAmount(BigDecimal amount) {
         MoneyUtils.checkNotNull(amount, "Amount must not be null");
-        if (this.amount.equals(amount)) {
+        if (hasSameAmount(amount)) {
             return this;
         }
         return BigMoney.of(currency, amount);
@@ -1675,9 +1675,26 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
         if (other instanceof BigMoney) {
             BigMoney otherMoney = (BigMoney) other;
             return currency.equals(otherMoney.getCurrencyUnit()) &&
-                    amount.equals(otherMoney.amount);
+                    hasSameAmount(otherMoney.amount);
         }
         return false;
+    }
+
+    /**
+     * Check whether a given {@code otherAmount} is of the same value with the
+     * current {@link #amount} according to the
+     * {@link java.math.BigDecimal#equals(Object)}
+     * and {@link java.math.BigDecimal#compareTo(java.math.BigDecimal)}
+     * methods' semantics.
+     *
+     * @param otherAmount the monetary amount to compare with, not null
+     * @return {@code true} if {@code otherAmount} and {@link #amount} are equal
+     * in value in spite of their representation, {@code false} otherwise.
+     * @see java.math.BigDecimal#compareTo(Object)
+     * @see java.math.BigDecimal#equals(Object)
+     */
+    private boolean hasSameAmount(BigDecimal otherAmount) {
+        return amount.compareTo(otherAmount) == 0;
     }
 
     /**

--- a/src/test/java/org/joda/money/TestBigMoney.java
+++ b/src/test/java/org/joda/money/TestBigMoney.java
@@ -2367,6 +2367,13 @@ public class TestBigMoney {
         assertEquals(a.equals(new Object()), false);
     }
 
+    public void test_equals_with_different_big_decimal_of_amount() {
+        BigMoney a = BigMoney.of(CurrencyUnit.GBP, new BigDecimal("100"));
+        BigMoney b = BigMoney.of(CurrencyUnit.GBP, new BigDecimal("1E+2"));
+
+        assertEquals(a, b);
+    }
+
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------


### PR DESCRIPTION
The current behaviour of the BigMoney#equals hurt me with an "equal" amounts in different BigDecimal representation as in the following example

![screen shot 2014-07-12 at 12 07 54 pm](https://cloud.githubusercontent.com/assets/1078842/3561245/f96ea47a-09b1-11e4-93d1-d0fd83e5ba98.png)

As stated in the [BigDecimal#equals javadocs](http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#equals%28java.lang.Object%29)

> Compares this BigDecimal with the specified Object for equality. Unlike compareTo, this method considers two BigDecimal objects equal only if they are equal in value and scale (thus 2.0 is not equal to 2.00 when compared by this method).

So

![screen shot 2014-07-12 at 11 36 12 am](https://cloud.githubusercontent.com/assets/1078842/3561246/18f8c000-09b2-11e4-8ecd-ce3f772fba42.png)

According to the mentioned above, this pull request brings changes based on the [BigDecimal#compareTo](http://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#compareTo%28java.math.BigDecimal%29) suggestions

> Compares this BigDecimal with the specified BigDecimal. Two BigDecimal objects that are equal in value but have a different scale (like 2.0 and 2.00) are considered equal by this method. This method is provided in preference to individual methods for each of the six boolean comparison operators (<, ==, >, >=, !=, <=). The suggested idiom for performing these comparisons is: (x.compareTo(y) <op> 0), where <op> is one of the six comparison operators.
