### PR TITLE
Added test-output directory created when you run testng tests from within Eclipse.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /nbproject/
 .idea
 *.iml
+/test-output/


### PR DESCRIPTION
Running TestNG tests from within Eclipse creates this directory by default. Trivial, but annoying. 
