### PR TITLE
Fix minor typos in javadoc

### DIFF
--- a/src/main/java/org/joda/money/BigMoney.java
+++ b/src/main/java/org/joda/money/BigMoney.java
@@ -1618,7 +1618,7 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      * The compared values must be in the same currency.
      * 
      * @param other  the other monetary value, not null
-     * @return true is this is greater than the specified monetary value
+     * @return true iff this is greater than the specified monetary value
      * @throws CurrencyMismatchException if the currencies differ
      * @see #equals(Object)
      */
@@ -1631,7 +1631,7 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      * The compared values must be in the same currency.
      * 
      * @param other  the other monetary value, not null
-     * @return true is this is greater than the specified monetary value
+     * @return true iff this is greater than the specified monetary value
      * @throws CurrencyMismatchException if the currencies differ
      */
     public boolean isGreaterThan(BigMoneyProvider other) {
@@ -1643,7 +1643,7 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      * The compared values must be in the same currency.
      * 
      * @param other  the other monetary value, not null
-     * @return true is this is less than the specified monetary value
+     * @return true iff this is less than the specified monetary value
      * @throws CurrencyMismatchException if the currencies differ
      */
     public boolean isLessThan(BigMoneyProvider other) {

--- a/src/main/java/org/joda/money/BigMoney.java
+++ b/src/main/java/org/joda/money/BigMoney.java
@@ -1618,7 +1618,7 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      * The compared values must be in the same currency.
      * 
      * @param other  the other monetary value, not null
-     * @return true iff this is greater than the specified monetary value
+     * @return true iff this is equal to the specified monetary value
      * @throws CurrencyMismatchException if the currencies differ
      * @see #equals(Object)
      */


### PR DESCRIPTION
Replaced 'is this is' typos with 'iff this is' as well as a copy paste error