### PR TITLE
Check for non-null Locale in MoneyPrintContext constructor

### DIFF
--- a/src/main/java/org/joda/money/format/MoneyPrintContext.java
+++ b/src/main/java/org/joda/money/format/MoneyPrintContext.java
@@ -36,6 +36,7 @@ public final class MoneyPrintContext {
      * @param locale  the locale, not null
      */
     MoneyPrintContext(Locale locale) {
+        MoneyFormatter.checkNotNull(locale, "Locale must not be null");
         this.locale = locale;
     }
 


### PR DESCRIPTION
The comment states that the locale must not be null but there isn't any actual check.