### PR TITLE
Fix stripTrailingZeros() on early Android versions

### DIFF
--- a/src/main/java/org/joda/money/BigMoney.java
+++ b/src/main/java/org/joda/money/BigMoney.java
@@ -111,6 +111,10 @@ public final class BigMoney implements BigMoneyProvider, Comparable<BigMoneyProv
      */
     public static BigMoney of(CurrencyUnit currency, double amount) {
         MoneyUtils.checkNotNull(currency, "Currency must not be null");
+        // if statement added to support Android before v30 where stripTrailingZeros() is broken, see #129
+        if (amount == 0d) {
+            return zero(currency);
+        }
         return BigMoney.of(currency, BigDecimal.valueOf(amount).stripTrailingZeros());
     }
 

--- a/src/test/java/org/joda/money/TestBigMoney.java
+++ b/src/test/java/org/joda/money/TestBigMoney.java
@@ -196,6 +196,15 @@ public class TestBigMoney {
     }
 
     @Test
+    public void test_factory_of_Currency_double_zero() {
+        assertEquals(BigMoney.of(GBP, BigDecimal.valueOf(0L, 0)), BigMoney.of(GBP, 0d));
+        assertEquals(BigMoney.of(GBP, BigDecimal.valueOf(0L, 0)), BigMoney.of(GBP, -0d));
+        assertEquals(BigMoney.of(GBP, BigDecimal.valueOf(0L, 0)), BigMoney.of(GBP, 0.0d));
+        assertEquals(BigMoney.of(GBP, BigDecimal.valueOf(0L, 0)), BigMoney.of(GBP, 0.00d));
+        assertEquals(BigMoney.of(GBP, BigDecimal.valueOf(0L, 0)), BigMoney.of(GBP, -0.0d));
+    }
+
+    @Test
     public void test_factory_of_Currency_double_medium() {
         BigMoney test = BigMoney.of(GBP, 2000d);
         assertEquals(GBP, test.getCurrencyUnit());


### PR DESCRIPTION
Provide a simple workaround