### PR TITLE
Handle currency data on Java 21

### DIFF
--- a/src/main/java/org/joda/money/CurrencyUnit.java
+++ b/src/main/java/org/joda/money/CurrencyUnit.java
@@ -577,6 +577,10 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>, Serializabl
      * @return the JDK currency instance, never null
      */
     public String getSymbol() {
+        // Java 21 currency data uses a symbol, we want to retain this as XXX
+        if ("XXX".equals(code)) {
+            return code;
+        }
         try {
             return Currency.getInstance(code).getSymbol();
         } catch (IllegalArgumentException ex) {
@@ -597,6 +601,10 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>, Serializabl
      */
     public String getSymbol(Locale locale) {
         MoneyUtils.checkNotNull(locale, "Locale must not be null");
+        // Java 21 currency data uses a symbol, we want to retain this as XXX
+        if ("XXX".equals(code)) {
+            return code;
+        }
         try {
             return Currency.getInstance(code).getSymbol(locale);
         } catch (IllegalArgumentException ex) {

--- a/src/test/java/org/joda/money/TestCurrencyUnit.java
+++ b/src/test/java/org/joda/money/TestCurrencyUnit.java
@@ -712,6 +712,8 @@ class TestCurrencyUnit {
             Locale.setDefault(Locale.UK);
             CurrencyUnit test = CurrencyUnit.of("XXX");
             assertThat(test.getSymbol(Locale.FRANCE)).isEqualTo("XXX");
+            test = CurrencyUnit.of("XXX");
+            assertThat(test.getSymbol(Locale.US)).isEqualTo("XXX");
         } finally {
             Locale.setDefault(loc);
         }


### PR DESCRIPTION
* Adjust code so the symbol for currency XXX remains as XXX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced currency symbol representation for the code "XXX" to ensure it returns the code itself instead of a different symbol.
  
- **Bug Fixes**
	- Improved handling of currency symbols for the `Locale.US`, ensuring accurate representation in tests for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->