### PR TITLE
Basic setup for Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: 21
         distribution: 'temurin'
         cache: 'maven'
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,15 @@ Various documentation is available:
 
 
 ### Releases
-[Release 1.0.4](https://www.joda.org/joda-money/download.html) is the current release.
-This release is considered stable and worthy of the 1.x tag.
-It depends on Java SE 8 or later.
+The 2.x branch is compatible with Java SE 21 or later.
 
-Joda-Money does have a *compile-time* dependency on Joda-Convert, but this is not required at runtime
-thanks to the magic of annotations.
+The 1.x branch is compatible with Java SE 8 or later.
+
+v2.x releases are compatible with v1.x releases - except for the Java SE version and `module-info.class` file.
+
+Joda-Money has no mandatory dependencies.
+There is a *compile-time* dependency on [Joda-Convert](https://www.joda.org/joda-convert/),
+but this is not required at runtime thanks to the magic of annotations.
 
 Available in the [Maven Central repository](https://search.maven.org/search?q=g:org.joda%20AND%20a:joda-money&core=gav)
 
@@ -85,7 +88,7 @@ Tidelift will coordinate the fix and disclosure.
 
 ### Release process
 
-* Update version (README.md, index.md, changes.xml)
+* Update version (index.md, changes.xml)
 * Commit and push
 * In an admin window `gpg-connect-agent -v`
 * Switch to Java 11

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <artifactId>joda-money</artifactId>
   <packaging>jar</packaging>
   <name>Joda-Money</name>
-  <version>1.0.5-SNAPSHOT</version>
-  <description>Money representation and formatting</description>
+  <version>2.0.0-RC1-SNAPSHOT</version>
+  <description>Money representation and formatting, compatible with Java 21+</description>
   <url>https://www.joda.org/joda-money/</url>
 
   <!-- ==================================================================== -->
@@ -100,7 +100,7 @@
     </resources>
     <!-- define build -->
     <plugins>
-      <!-- Enforce Maven 3.6.0 and Java 11+ -->
+      <!-- Enforce Maven 3.8.0 and Java 21+ -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -116,42 +116,12 @@
                   <version>3.8.0</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[11,)</version>
+                  <version>[21,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <!-- Compile twice -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <!-- compile first with module-info for Java 9 -->
-          <execution>
-            <id>default-compile</id>
-            <configuration>
-              <release>9</release>
-            </configuration>
-          </execution>
-          <!-- then compile without module-info for Java 8 -->
-          <execution>
-            <id>base-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <excludes>
-                <exclude>module-info.java</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
-        <!-- setup defaults for compile and testCompile -->
-        <configuration>
-          <release>8</release>
-        </configuration>
       </plugin>
       <!-- Hack to extract dependencies for Surefire plugin -->
       <plugin>
@@ -229,9 +199,9 @@
             </goals>
           </execution>
         </executions>
-        <!-- Javadoc uses source 11 to pickup the module settings -->
+        <!-- Javadoc uses source 21 to pickup the module settings -->
         <configuration>
-          <source>11</source>
+          <source>21</source>
         </configuration>
       </plugin>
       <!-- Setup source jar -->
@@ -581,7 +551,7 @@
           </reportSet>
         </reportSets>
         <configuration>
-          <source>11</source>
+          <source>21</source>
         </configuration>
       </plugin>
       <!-- Setup Surefire report -->
@@ -835,9 +805,8 @@
     <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
 
     <!-- Properties for maven-compiler-plugin -->
-    <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.fork>true</maven.compiler.fork>
 
     <!-- Properties for maven-javadoc-plugin -->
@@ -846,7 +815,7 @@
     <doclint>none</doclint>
 
     <!-- Properties for maven-checkstyle-plugin -->
-    <checkstyle.version>8.45.1</checkstyle.version>
+    <checkstyle.version>10.17.0</checkstyle.version>
     <checkstyle.config.location>src/main/checkstyle/checkstyle.xml</checkstyle.config.location>
     <linkXRef>false</linkXRef>
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,12 @@
   <body>
 
     <!-- types are add, fix, remove, update -->
+    <release version="2.0.0-RC1" date="SNAPSHOT" description="Version 2.0.0-RC1">
+      <action dev="jodastephen" type="add">
+        Major version based on Java SE 21.
+        Intended to be effectively compatible with v1.x.
+      </action>
+    </release>
     <release version="1.0.4" date="2023-10-29" description="v1.0.4">
       <action dev="jodastephen" type="add">
         Add isGreaterThanOrEqual() and isLessThanOrEqual() to money classes.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -70,10 +70,13 @@ As a flavour of Joda-Money, here is some example code:
 
 ## <i></i> Releases
 
-[Release 1.0.4](download.html) is the current release.
-This release is considered stable and worthy of the 1.x tag.
+The 2.x branch is compatible with Java SE 21 or later.
 
-Joda-Money requires Java SE 8 or later and has [no dependencies](dependencies.html).
+The 1.x branch is compatible with Java SE 8 or later.
+
+v2.x releases are compatible with v1.x releases - except for the Java SE version and `module-info.class` file.
+
+Joda-Money has no mandatory dependencies.
 There is a *compile-time* dependency on [Joda-Convert](https://www.joda.org/joda-convert/),
 but this is not required at runtime thanks to the magic of annotations.
 


### PR DESCRIPTION
* Adjust code so the symbol for currency XXX remains as XXX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced version `2.0.0-RC1` with compatibility for Java SE 21 or later.
  
- **Documentation**
	- Updated README and site documentation to clarify version compatibility and dependency requirements for Joda-Money.

- **Bug Fixes**
	- Enhanced compatibility with modern Java versions and streamlined build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->