### PR TITLE
Prepare for v2.0.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-If a security issue occurs, only the latest version is guaranteed to be patched.
+If a security issue occurs, only the latest versions of v2.x and v1.x are guaranteed to be patched.
 
 ## Reporting a Vulnerability
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ Tidelift will coordinate the fix and disclosure.
 
 * Update version (index.md, changes.xml)
 * Commit and push
-* In an admin window `gpg-connect-agent -v`
-* Switch to Java 11
+* Switch to Java 21
 * `mvn clean release:clean release:prepare release:perform`
 * `git fetch`
 * Website will be built and released by GitHub Actions

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@ Joda-Money
 Joda-Money is a monetary library that fills the gap in the JDK
 by providing a Money class and associated formatting.
 
-The release runs on JDK 6 or later.
+The release runs on JDK 21 or later.
 
 See https://www.joda.org/joda-money/changes-report.html for changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>joda-money</artifactId>
   <packaging>jar</packaging>
   <name>Joda-Money</name>
-  <version>2.0.0-RC1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <description>Money representation and formatting, compatible with Java 21+</description>
   <url>https://www.joda.org/joda-money/</url>
 
@@ -880,7 +880,7 @@
   <properties>
     <!-- Dependencies -->
     <assertj.version>3.26.3</assertj.version>
-    <joda-convert.version>2.2.3</joda-convert.version>
+    <joda-convert.version>3.0.1</joda-convert.version>
     <junit.version>5.11.0</junit.version>
 
     <!-- Common control parameters -->
@@ -904,12 +904,12 @@
     <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
     <maven-jxr-plugin.version>3.5.0</maven-jxr-plugin.version>
     <maven-plugin-plugin.version>3.15.0</maven-plugin-plugin.version>
-    <maven-pmd-plugin.version>3.25.0</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.24.0</maven-pmd-plugin.version><!-- 3.25.0 throws NoSuchMethodException -->
     <maven-project-info-reports-plugin.version>3.6.2</maven-project-info-reports-plugin.version><!-- 3.7.0 has error -->
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-repository-plugin.version>2.4</maven-repository-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+    <maven-site-plugin.version>3.12.1</maven-site-plugin.version><!-- 3.20.0 throws ComponentLookupException -->
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.5.0</maven-surefire-report-plugin.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,10 +8,10 @@
   <body>
 
     <!-- types are add, fix, remove, update -->
-    <release version="2.0.0-RC1" date="SNAPSHOT" description="Version 2.0.0-RC1">
+    <release version="2.0.0" date="2024-10-06" description="Version 2.0.0">
       <action dev="jodastephen" type="add">
         Major version based on Java SE 21.
-        Intended to be effectively compatible with v1.x.
+        Intended to be fully compatible with v1.x.
       </action>
     </release>
     <release version="1.0.5" date="2024-08-25" description="v1.0.5">

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -70,9 +70,9 @@ As a flavour of Joda-Money, here is some example code:
 
 ## <i></i> Releases
 
-The 2.x branch is compatible with Java SE 21 or later.
+The 2.x branch (v2.0.0) is compatible with Java SE 21 or later.
 
-The 1.x branch is compatible with Java SE 8 or later.
+The 1.x branch (v1.0.5) is compatible with Java SE 8 or later.
 
 v2.x releases are compatible with v1.x releases - except for the Java SE version and `module-info.class` file.
 
@@ -81,12 +81,13 @@ There is a *compile-time* dependency on [Joda-Convert](https://www.joda.org/joda
 but this is not required at runtime thanks to the magic of annotations.
 
 Available in [Maven Central](https://search.maven.org/search?q=g:org.joda%20AND%20a:joda-money&core=gav).
+[GitHub release bundles](https://github.com/JodaOrg/joda-money/releases).
 
 ```xml
 <dependency>
   <groupId>org.joda</groupId>
   <artifactId>joda-money</artifactId>
-  <version>1.0.5</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
* Update Joda-Convert to fully modular v3.0.0
* Bring build files in line with Joda-Convert
* Use release instead of source/target in pom.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated security policy to ensure timely patches for the latest versions.
	- Enhanced clarity in the release history regarding compatibility with previous versions.

- **Documentation**
	- Updated Java version requirements in the README and release notes to JDK 21.
	- Added version numbers for the 2.x and 1.x branches in the documentation.
	- Included a link to GitHub release bundles for improved access to release information.

- **Bug Fixes**
	- Clarified compatibility statements and improved currency symbol consistency in release history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->